### PR TITLE
feat: Configure local model endpoint via JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can configure OpenCode using environment variables:
 | `AZURE_OPENAI_ENDPOINT`    | For Azure OpenAI models                                |
 | `AZURE_OPENAI_API_KEY`     | For Azure OpenAI models (optional when using Entra ID) |
 | `AZURE_OPENAI_API_VERSION` | For Azure OpenAI models                                |
-| `LOCAL_ENDPOINT`           | For self-hosted models                                 |
+| `LOCAL_ENDPOINT`           | For self-hosted models (fallback if not set in config) |
 | `SHELL`                    | Default shell to use (if not specified in config)      |
 
 ### Shell Configuration
@@ -143,6 +143,9 @@ This is useful if you want to use a different shell than your default system she
     "openrouter": {
       "apiKey": "your-api-key",
       "disabled": false
+    },
+    "local": {
+      "localEndpoint": "http://localhost:1234/v1"
     }
   },
   "agents": {
@@ -567,34 +570,72 @@ The AI assistant can access LSP features through the `diagnostics` tool, allowin
 
 While the LSP client implementation supports the full LSP protocol (including completions, hover, definition, etc.), currently only diagnostics are exposed to the AI assistant.
 
-## Using a self-hosted model provider
+## Using a Self-Hosted Model Provider
 
-OpenCode can also load and use models from a self-hosted (OpenAI-like) provider.
-This is useful for developers who want to experiment with custom models.
+OpenCode supports connecting to self-hosted (OpenAI-like) model providers. This is useful for running local LLMs, custom models, or models from providers not directly integrated.
 
-### Configuring a self-hosted provider 
+### Configuration Steps
 
-You can use a self-hosted model by setting the `LOCAL_ENDPOINT` environment variable.
-This will cause OpenCode to load and use the models from the specified endpoint.
+1.  **Configure the Endpoint:**
+    The primary way to configure your self-hosted provider is by adding its details to your OpenCode configuration file (`$HOME/.opencode.json` or local `.opencode.json`).
 
-```bash
-LOCAL_ENDPOINT=http://localhost:1235/v1
-```
-
-### Configuring a self-hosted model
-
-You can also configure a self-hosted model in the configuration file under the `agents` section:
-
-```json
-{
-  "agents": {
-    "coder": {
-      "model": "local.granite-3.3-2b-instruct@q8_0",
-      "reasoningEffort": "high"
+    Add a `local` provider entry with the `localEndpoint` field:
+    ```json
+    {
+      "providers": {
+        "local": {
+          "localEndpoint": "http://localhost:1234/v1"
+        }
+        // ... other providers
+      }
+      // ... other configurations
     }
-  }
-}
-```
+    ```
+    Replace `http://localhost:1234/v1` with the actual URL of your self-hosted model provider's API endpoint (usually ending in `/v1`).
+
+    As a fallback, OpenCode will check the `LOCAL_ENDPOINT` environment variable if `providers.local.localEndpoint` is not set in the configuration file. The JSON configuration takes precedence.
+    ```bash
+    # Example of setting the environment variable (used if not in JSON config)
+    export LOCAL_ENDPOINT="http://localhost:1234/v1"
+    ```
+
+2.  **Select the Model for an Agent:**
+    Once the endpoint is configured, OpenCode will attempt to list available models from that endpoint. To use one of these models, you need to specify it in the `agents` section of your configuration file. The model ID will typically be prefixed with `local.`.
+
+    ```json
+    {
+      "agents": {
+        "coder": {
+          "model": "local.your-model-id-from-endpoint"
+        }
+        // ... other agents
+      }
+      // ... other configurations
+    }
+    ```
+    Replace `your-model-id-from-endpoint` with the actual model ID as reported by your local endpoint (e.g., `local.Llama-3-8B-Instruct`, `local.Mistral-7B-v0.1@gguf`). You can often find these IDs by checking the `/v1/models` endpoint of your local server or its documentation.
+
+    For example, if your local server provides a model named `granite-3.3-2b-instruct@q8_0`, you would use:
+    ```json
+    {
+      "agents": {
+        "coder": {
+          "model": "local.granite-3.3-2b-instruct@q8_0",
+          "reasoningEffort": "high" // Optional, if model supports it
+        }
+      }
+    }
+    ```
+
+### How it Works
+
+When OpenCode starts:
+- It checks for `providers.local.localEndpoint` in your JSON configuration.
+- If not found, it checks for the `LOCAL_ENDPOINT` environment variable.
+- If an endpoint is determined, OpenCode queries the `/v1/models` path (or `/api/v0/models` for some LM Studio versions) on that endpoint to get a list of available models.
+- These models are then available for use in your agent configurations, prefixed with `local.`.
+
+This setup allows you to seamlessly integrate various locally hosted models into your OpenCode workflow.
 
 ## Development
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,8 +51,9 @@ type Agent struct {
 
 // Provider defines configuration for an LLM provider.
 type Provider struct {
-	APIKey   string `json:"apiKey"`
-	Disabled bool   `json:"disabled"`
+	APIKey        string `json:"apiKey"`
+	Disabled      bool   `json:"disabled"`
+	LocalEndpoint string `json:"localEndpoint,omitempty"`
 }
 
 // Data defines storage configuration.

--- a/internal/llm/models/local.go
+++ b/internal/llm/models/local.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/opencode-ai/opencode/internal/config"
 	"github.com/opencode-ai/opencode/internal/logging"
 	"github.com/spf13/viper"
 )
@@ -22,39 +23,64 @@ const (
 )
 
 func init() {
-	if endpoint := os.Getenv("LOCAL_ENDPOINT"); endpoint != "" {
-		localEndpoint, err := url.Parse(endpoint)
-		if err != nil {
-			logging.Debug("Failed to parse local endpoint",
-				"error", err,
-				"endpoint", endpoint,
-			)
-			return
+	cfg := config.Get()
+	var endpoint string
+
+	if cfg != nil && cfg.Providers != nil {
+		if providerCfg, ok := cfg.Providers[ProviderLocal]; ok && providerCfg.LocalEndpoint != "" {
+			endpoint = providerCfg.LocalEndpoint
+			logging.Debug("Using local endpoint from config", "endpoint", endpoint)
 		}
-
-		load := func(url *url.URL, path string) []localModel {
-			url.Path = path
-			return listLocalModels(url.String())
-		}
-
-		models := load(localEndpoint, lmStudioBetaModelsPath)
-
-		if len(models) == 0 {
-			models = load(localEndpoint, localModelsPath)
-		}
-
-		if len(models) == 0 {
-			logging.Debug("No local models found",
-				"endpoint", endpoint,
-			)
-			return
-		}
-
-		loadLocalModels(models)
-
-		viper.SetDefault("providers.local.apiKey", "dummy")
-		ProviderPopularity[ProviderLocal] = 0
 	}
+
+	if endpoint == "" {
+		envEndpoint := os.Getenv("LOCAL_ENDPOINT")
+		if envEndpoint != "" {
+			endpoint = envEndpoint
+			logging.Debug("Using local endpoint from environment variable", "endpoint", endpoint)
+		}
+	}
+
+	if endpoint == "" {
+		logging.Debug("No local endpoint configured (checked config 'providers.local.localEndpoint' and LOCAL_ENDPOINT env var). Skipping local model loading.")
+		return
+	}
+
+	localEndpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		logging.Warn("Failed to parse local endpoint URL",
+			"error", err,
+			"endpointURL", endpoint,
+		)
+		return
+	}
+
+	load := func(url *url.URL, path string) []localModel {
+		// Create a copy of the URL to avoid modifying the original localEndpointURL
+		targetURL := *url
+		targetURL.Path = path
+		return listLocalModels(targetURL.String())
+	}
+
+	models := load(localEndpointURL, lmStudioBetaModelsPath)
+
+	if len(models) == 0 {
+		models = load(localEndpointURL, localModelsPath)
+	}
+
+	if len(models) == 0 {
+		logging.Warn("No local models found",
+			"endpointURL", localEndpointURL.String(),
+		)
+		return
+	}
+
+	loadLocalModels(models)
+
+	// Set a dummy API key for the local provider so it's considered active
+	// by the validation logic in config.go, even if no real API key is needed.
+	viper.SetDefault("providers.local.apiKey", "dummy")
+	ProviderPopularity[ProviderLocal] = 0 // Initialize popularity
 }
 
 type localModelList struct {

--- a/opencode-schema.json
+++ b/opencode-schema.json
@@ -203,6 +203,11 @@
       },
       "type": "object"
     },
+    "autoCompact": {
+      "type": "boolean",
+      "description": "Automatically compact data on exit",
+      "default": true
+    },
     "contextPaths": {
       "default": [
         ".github/copilot-instructions.md",
@@ -344,6 +349,10 @@
             "description": "Whether the provider is disabled",
             "type": "boolean"
           },
+          "localEndpoint": {
+            "description": "The endpoint URL for a self-hosted (local) model provider (e.g., http://localhost:1234/v1). This is specific to the 'local' provider type.",
+            "type": "string"
+          },
           "provider": {
             "description": "Provider type",
             "enum": [
@@ -354,7 +363,8 @@
               "openrouter",
               "bedrock",
               "azure",
-              "vertexai"
+              "vertexai",
+              "local"
             ],
             "type": "string"
           }
@@ -362,6 +372,23 @@
         "type": "object"
       },
       "description": "LLM provider configurations",
+      "type": "object"
+    },
+    "shell": {
+      "description": "Shell configuration",
+      "properties": {
+        "args": {
+          "description": "Arguments for the shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "Path to the shell executable",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "tui": {


### PR DESCRIPTION
This change allows you to specify the endpoint for self-hosted local models directly in the `.opencode.json` configuration file.

Key changes:
- Added `localEndpoint` field to `providers.local` in the JSON config. This is now the primary way to set the local model endpoint.
- The `LOCAL_ENDPOINT` environment variable now serves as a fallback if `localEndpoint` is not specified in the JSON configuration.
- Updated `internal/llm/models/local.go` to reflect this precedence.
- Updated `opencode-schema.json` to include `localEndpoint` and recognize "local" as a provider type.
- Updated `README.md` with detailed instructions and examples for configuring and using local models via the new JSON field.

This addresses the issue where you could only configure the local model endpoint via an environment variable, providing a more integrated and user-friendly configuration experience.